### PR TITLE
Improved Error Messaging for Entity Update

### DIFF
--- a/app/services/v1/partners/entities_service.rb
+++ b/app/services/v1/partners/entities_service.rb
@@ -26,7 +26,7 @@ class V1::Partners::EntitiesService
     if entity.update(params)
       return entity.reload
     else
-      raise UpdateFailureError.new("Error to update entity: #{entity.errors}")
+      raise UpdateFailureError.new("Error to update entity: #{entity.errors.full_messages.join(', ')}")
     end
   end
 end


### PR DESCRIPTION
## Description:

### Overview:
This PR addresses an issue with the error messaging when attempting to update an entity with invalid data. Previously, the error message returned was not user-friendly and lacked clarity, making it difficult for developers and users to understand the exact nature of the error.

### Issue:
When an update to an entity failed due to invalid data, the API returned the following error message:
```
{
    "message": "Error to update entity: #<ActiveModel::Errors:0x000055fa37ea3198>"
}
```

This message was not only uninformative but also exposed internal object references, which is not ideal for security and user experience.

### Resolution:
The error messaging has been refined to provide a clear and concise description of the validation error. With this fix, if an entity update fails, the API will return:
```
{
    "message": "Error to update entity: Name can't be blank"
}
```

This improved message directly informs the user about the nature of the validation error, enhancing the API's usability and error handling.